### PR TITLE
[Nexters/www-be#77] Add currentUserName and Fix userName at join

### DIFF
--- a/src/main/java/com/promise8/wwwbe/model/dto/res/MeetingGetResDto.java
+++ b/src/main/java/com/promise8/wwwbe/model/dto/res/MeetingGetResDto.java
@@ -21,11 +21,12 @@ public class MeetingGetResDto {
     private long meetingId;
     @ApiModelProperty(value = "meetingName", required = true, notes = "약속 방 이름")
     private String meetingName;
-
     @ApiModelProperty(value = "minimumAlertMembers", required = true, notes = "약속 방의 알림 최소 인원")
     private Long minimumAlertMembers;
     @ApiModelProperty(value = "hostName", required = true, notes = "약속 방의 방장 이름")
     private String hostName;
+    @ApiModelProperty(value = "currentUserName", notes = "최근에 사용한 본인의 이름")
+    private String currentUserName;
     @ApiModelProperty(value = "isHost", required = true, notes = "약속 방에서 내가 방장인지 여부")
     private Boolean isHost;
     @ApiModelProperty(value = "joinedUserCount", required = true, notes = "약속 방에 참여한 인원 수")
@@ -70,6 +71,7 @@ public class MeetingGetResDto {
                 .meetingName(meetingEntity.getMeetingName())
                 .minimumAlertMembers(meetingEntity.getConditionCount())
                 .hostName(confirmedPromiseResDto.getHostName())
+                .currentUserName(meetingEntity.getCreator().getUserName())
                 .isHost(meetingEntity.getCreator().getUserId() == currentUserId)
                 .joinedUserCount(isNoMeetingUser ? 0 : meetingEntity.getMeetingUserEntityList().size())
                 .votingUserCount(confirmedPromiseResDto.getVotingUserCount())

--- a/src/main/java/com/promise8/wwwbe/repository/MeetingPlaceRepository.java
+++ b/src/main/java/com/promise8/wwwbe/repository/MeetingPlaceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.HashSet;
 import java.util.List;
 
 public interface MeetingPlaceRepository extends JpaRepository<MeetingPlaceEntity, Long> {
@@ -18,4 +19,8 @@ public interface MeetingPlaceRepository extends JpaRepository<MeetingPlaceEntity
             @Param("meetingUserEntity") MeetingUserEntity meetingUserEntity,
             @Param("placeVoteEntityIds") List<Long> placeVoteEntityIds);
     List<MeetingPlaceEntity> findByMeetingUserEntity(MeetingUserEntity meetingUserEntity);
+
+    @Query(value = "select mp.promisePlace from meeting_place mp " +
+            "where mp.meetingUserEntity = :meetingUserEntity")
+    public HashSet<String> getExistMeetingPlaceList(MeetingUserEntity meetingUserEntity);
 }

--- a/src/main/java/com/promise8/wwwbe/service/MeetingService.java
+++ b/src/main/java/com/promise8/wwwbe/service/MeetingService.java
@@ -207,9 +207,11 @@ public class MeetingService {
         meetingUserTimetableRepository.saveAll(meetingUserTimetableEntityList);
 
         HashSet<String> existPromisePlaceHashSet = new HashSet<>();
-        meetingEntity.getMeetingUserEntityList().forEach(meetingUser -> {
-            existPromisePlaceHashSet.addAll(meetingPlaceRepository.getExistMeetingPlaceList(meetingUser));
-        });
+        if (meetingEntity.getMeetingUserEntityList() != null) {
+            meetingEntity.getMeetingUserEntityList().forEach(meetingUser -> {
+                existPromisePlaceHashSet.addAll(meetingPlaceRepository.getExistMeetingPlaceList(meetingUser));
+            });
+        }
 
         List<MeetingPlaceEntity> meetingPlaceEntityList = new ArrayList<>();
         joinMeetingReqDto.getPromisePlaceList().forEach(req -> {

--- a/src/main/java/com/promise8/wwwbe/service/MeetingService.java
+++ b/src/main/java/com/promise8/wwwbe/service/MeetingService.java
@@ -184,7 +184,8 @@ public class MeetingService {
                 meetingRepository.findById(meetingId).orElseThrow(() -> new BizException(BaseErrorCode.NOT_EXIST_MEETING));
         UserEntity userEntity =
                 userRepository.findById(userId).orElseThrow(() -> new BizException(BaseErrorCode.NOT_EXIST_USER));
-
+        userEntity.setUserName(joinMeetingReqDto.getNickname());
+        userRepository.save(userEntity);
 
         MeetingUserEntity meetingUserEntity = meetingUserRepository.save(MeetingUserEntity.builder()
                 .userEntity(userEntity)

--- a/src/main/java/com/promise8/wwwbe/service/MeetingService.java
+++ b/src/main/java/com/promise8/wwwbe/service/MeetingService.java
@@ -68,8 +68,15 @@ public class MeetingService {
         meetingUserTimetableRepository.saveAll(meetingUserTimetableEntityList);
 
         // TODO Refactoring
+        HashSet<String> isExistPlaceHashSet = new HashSet<>();
         List<MeetingPlaceEntity> meetingPlaceEntityList = new ArrayList<>();
         for (String promisePlace : meetingCreateReqDto.getPromisePlaceList()) {
+            if (isExistPlaceHashSet.contains(promisePlace)) {
+                continue;
+            } else {
+                isExistPlaceHashSet.add(promisePlace);
+            }
+
             meetingPlaceEntityList.add(MeetingPlaceEntity.builder()
                     .promisePlace(promisePlace)
                     .isConfirmed(false)
@@ -199,13 +206,25 @@ public class MeetingService {
 
         meetingUserTimetableRepository.saveAll(meetingUserTimetableEntityList);
 
-        List<MeetingPlaceEntity> meetingPlaceEntityList = joinMeetingReqDto.getPromisePlaceList().stream()
-                .map(place -> meetingPlaceRepository.save(MeetingPlaceEntity.builder()
-                        .meetingUserEntity(meetingUserEntity)
-                        .promisePlace(place)
-                        .isConfirmed(false)
-                        .build()))
-                .collect(Collectors.toList());
+        HashSet<String> existPromisePlaceHashSet = new HashSet<>();
+        meetingEntity.getMeetingUserEntityList().forEach(meetingUser -> {
+            existPromisePlaceHashSet.addAll(meetingPlaceRepository.getExistMeetingPlaceList(meetingUser));
+        });
+
+        List<MeetingPlaceEntity> meetingPlaceEntityList = new ArrayList<>();
+        joinMeetingReqDto.getPromisePlaceList().forEach(req -> {
+            if (existPromisePlaceHashSet.contains(req)) {
+                return;
+            } else {
+                existPromisePlaceHashSet.add(req);
+            }
+
+            meetingPlaceEntityList.add(meetingPlaceRepository.save(MeetingPlaceEntity.builder()
+                    .meetingUserEntity(meetingUserEntity)
+                    .promisePlace(req)
+                    .isConfirmed(false)
+                    .build()));
+        });
 
         meetingPlaceRepository.saveAll(meetingPlaceEntityList);
         return meetingUserEntity.getMeetingUserId();


### PR DESCRIPTION
+ MeetingGetRes에 currentUserName을 추가한다.
   + meetingCode로 미팅방 참여여부 확인 후 default 닉네임으로 활용
+ joinMeeting 시 입력한 nickname을 UserEntity의 userName으로 갱신한다.