### PR TITLE
[Nexters/www-be#83] Fix cicd.yml rmi images

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,4 +39,6 @@ jobs:
             docker stop www-be
             docker rm www-be
             docker run -d --network www --name www-be -p 8080:8080 ${{ secrets.DOCKER_USER }}/www-be
-#            docker rmi $(docker images -f "dangling=true" -q)
+            if docker images -f "dangling=true" -q | grep . > /dev/null; then
+              docker rmi $(docker images -f "dangling=true" -q)
+            fi


### PR DESCRIPTION
[Nexters/www-be#83]

사용하지 않는 image를 삭제한다.